### PR TITLE
Fix array comparison

### DIFF
--- a/utilities/framer.js
+++ b/utilities/framer.js
@@ -130,7 +130,7 @@ function encode_utf8(s) {
 function arraysEqual(a1, a2) {
     if (a1.length != a2.length) return false;
 
-    for (var i = 0; i < a1; i++) {
+    for (var i = 0; i < a1.length; i++) {
         if (a1[i] != a2[i])
             return false;
     }


### PR DESCRIPTION
This fixes a bug checking server keys -- previously, the arrays were
always considered equal because they were of the same size and
the array elements were never checked.